### PR TITLE
更新

### DIFF
--- a/driver/driver.go
+++ b/driver/driver.go
@@ -2,12 +2,13 @@ package driver
 
 import (
 	"fmt"
-	"github.com/tebeka/selenium"
-	"github.com/tebeka/selenium/chrome"
-	"github.com/tebeka/selenium/log"
 	"net"
 	"strconv"
 	"time"
+
+	"github.com/tebeka/selenium"
+	"github.com/tebeka/selenium/chrome"
+	"github.com/tebeka/selenium/log"
 )
 
 var caps selenium.Capabilities
@@ -116,10 +117,22 @@ func Driver(url string) (*selenium.Service, *selenium.WebDriver, int) {
 		fmt.Println(err)
 		return nil, nil, 0
 	}
+
+	script := `
+    Object.defineProperty(navigator, 'webdriver', {
+        get: () => undefined
+    });
+	`
+	_, err2 := wd.ExecuteScript(script, nil)
+	if err2 != nil {
+		fmt.Println("Failed to execute JavaScript:", err)
+		return nil, nil, 0
+	}
+
 	for {
 		d, _ := time.ParseDuration("2s")
 		time.Sleep(d)
-		ele, err := wd.FindElement(selenium.ByXPATH, "/html/body/div[1]/form/div[13]/div[10]/div[3]/div/div/div")
+		ele, err := wd.FindElement(selenium.ByXPATH, "//*[@id='ctlNext']")
 		if err != nil || ele == nil {
 			// 问卷已关闭
 			ele, err := wd.FindElement(selenium.ByID, "divWorkError")

--- a/driver/functions.go
+++ b/driver/functions.go
@@ -4,10 +4,12 @@ import (
 	"filler/models"
 	"filler/utils"
 	"fmt"
-	"github.com/spf13/cast"
-	"github.com/tebeka/selenium"
 	"math/rand"
 	"strings"
+	"time"
+
+	"github.com/spf13/cast"
+	"github.com/tebeka/selenium"
 )
 
 type Page struct {
@@ -87,12 +89,82 @@ func (o *Operator) QuestionInput(index int, text string) bool {
 // QuestionSubmit 提交
 func (o *Operator) QuestionSubmit() bool {
 	driver := *o.driver
-	ele, _ := driver.FindElement(selenium.ByXPATH, "/html/body/div[1]/form/div[13]/div[10]/div[3]/div/div/div")
+	ele, _ := driver.FindElement(selenium.ByXPATH, "//*[@id='ctlNext']")
+	d1, _ := time.ParseDuration("1s")
+	time.Sleep(d1)
 	err := ele.Click()
+	d2, _ := time.ParseDuration("0.5s")
+	time.Sleep(d2)
+
+	tanchuang, _ := driver.FindElement(selenium.ByXPATH, "//*[@id='layui-layer1']/div[3]/a")
+	if tanchuang != nil {
+		tanchaung_err := tanchuang.Click()
+		d, _ := time.ParseDuration("2s")
+		time.Sleep(d)
+		if tanchaung_err != nil {
+			return false
+		}
+
+	}
+
+	yanzheng, _ := driver.FindElement(selenium.ByXPATH, "//*[@id='SM_BTN_1']")
+	if yanzheng != nil {
+		yanzheng_err := yanzheng.Click()
+		d, _ := time.ParseDuration("4s")
+		time.Sleep(d)
+		if yanzheng_err != nil {
+			return false
+		}
+
+	}
+
+	huakuai, _ := driver.FindElement(selenium.ByXPATH, "//*[@id='nc_1_n1z']")
+	if huakuai != nil {
+		// err = slideSlider(driver, huakuai)
+		err = slideSlider(driver, huakuai)
+		if err != nil {
+			fmt.Println("Failed to slide slider:", err)
+			return false
+		}
+		// huakuai_err := huakuai.Click()
+		// d, _ := time.ParseDuration("1s")
+		// time.Sleep(d)
+		// if huakuai_err != nil {
+		// 	return false
+		// }
+	}
 	if err != nil {
 		return false
 	}
 	return true
+}
+
+func slideSlider(wd selenium.WebDriver, sliderElement selenium.WebElement) error {
+	// 获取滑块的位置
+	location, err := sliderElement.Location()
+	if err != nil {
+		return err
+	}
+
+	wd.ButtonDown()
+	// 计算滑动目标位置（这里示意性地滑动到右侧，具体根据实际情况调整）
+	targetX := location.X + 100
+	targetY := location.Y + 50
+
+	// 模拟鼠标点击滑块并保持
+	sliderElement.MoveTo(targetX, targetY)
+
+	// 使用JavaScript执行滑动操作
+	// script := fmt.Sprintf("arguments[0].style.left='%dpx';", targetX)
+	// _, err = wd.ExecuteScript(script, []interface{}{sliderElement})
+	// if err != nil {
+	// 	return err
+	// }
+
+	// 等待一段时间以确保滑块移动完成（具体等待时间根据实际情况调整）
+	time.Sleep(2 * time.Second)
+
+	return nil
 }
 
 func (o *Operator) OptionInput(index, optionIndex int, text string) bool {
@@ -236,6 +308,7 @@ func (p *Page) GetStructure() []models.Question {
 func (p *Page) Submit(data []any) bool {
 	chrome, page, port := Driver(p.Url)
 
+	// fmt.Printf("chrome: %v, page: %v, port: %v\n", chrome, page, port)
 	operator := Operator{driver: page}
 
 	defer func(chrome *selenium.Service) {


### PR DESCRIPTION
本次更新修复其他问卷不能使用问题，以及绕过问卷星智能检测和滑动检测机制，推荐将driver目录下的driver.go的chromeCaps代码中的"--headless"和"--silent"注释掉使用，如图所示，让chrome显示出来，在测试chrome静默运行500份时发现丢了200份，还未找到原因
![image](https://github.com/way1and/questionless/assets/71595313/2fce57b1-0467-4846-befc-a181273ba05d)
